### PR TITLE
Add -fPIC flag for use in shared libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifdef WITH_OPENMP
   LDFLAGS += -fopenmp
 endif
 
-CFLAGS += -std=c99 -O3 -g -Wall -Werror -Wextra -pedantic
+CFLAGS += -std=c99 -O3 -g -Wall -Werror -Wextra -pedantic -fPIC
 LDLIBS += -lcrypto
 
 all: testfastpbkdf2 libfastpbkdf2.a bench benchmulti


### PR DESCRIPTION
To use libfastpbkdf2.a in a shared library, it is necessary for the code to be position independent. Adding the `-fPIC` flag solves that problem.